### PR TITLE
Allow generics on structs with `#[derive(RsHtml)]`

### DIFF
--- a/rshtml_core/src/lib.rs
+++ b/rshtml_core/src/lib.rs
@@ -16,8 +16,13 @@ use node::Node;
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, quote_spanned};
 use std::clone::Clone;
+use syn::Generics;
 
-pub fn process_template(template_name: String, struct_name: &Ident) -> TokenStream {
+pub fn process_template(
+    template_name: String,
+    struct_name: &Ident,
+    struct_generics: &Generics,
+) -> TokenStream {
     let config = Config::load_from_toml_or_default();
     let (_, layout) = config.views.clone();
 
@@ -35,6 +40,8 @@ pub fn process_template(template_name: String, struct_name: &Ident) -> TokenStre
 
     let text_size = text_size + ((text_size as f64 * 0.10) as usize).clamp(32, 512);
 
+    let (impl_generics, ty_generics, where_clause) = struct_generics.split_for_impl();
+
     //dbg!("DEBUG: Generated write_calls TokenStream:\n{}", compiled_ast_tokens.to_string());
 
     let rs = quote! {
@@ -50,7 +57,7 @@ pub fn process_template(template_name: String, struct_name: &Ident) -> TokenStre
 
             #rs
 
-            impl rshtml::traits::RsHtml for #struct_name {
+            impl #impl_generics rshtml::traits::RsHtml for #struct_name #ty_generics #where_clause {
                 fn fmt(&mut self, __f__: &mut dyn ::std::fmt::Write) -> ::std::fmt::Result {
 
                     #compiled_ast_tokens

--- a/rshtml_macro/src/lib.rs
+++ b/rshtml_macro/src/lib.rs
@@ -9,6 +9,7 @@ pub fn rshtml_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     let struct_name = &input.ident;
+    let struct_generics = &input.generics;
 
     let template_name = match parse_template_path_from_attrs(&input.attrs) {
         Ok(Some(path)) => path,
@@ -29,7 +30,11 @@ pub fn rshtml_derive(input: TokenStream) -> TokenStream {
         }
     };
 
-    TokenStream::from(process_template(template_name, struct_name))
+    TokenStream::from(process_template(
+        template_name,
+        struct_name,
+        struct_generics,
+    ))
 }
 
 fn parse_template_path_from_attrs(attrs: &[syn::Attribute]) -> syn::Result<Option<String>> {


### PR DESCRIPTION
Currently deriving `RsHtml` on a generic struct fails with a confusing compiler error

E.g.
```rust
#[derive(RsHtml)]
struct EditForm<'req> {
	context: rocket::form::Context<'req>,
}
```
causes this error message:
```
error[E0726]: implicit elided lifetime not allowed here
 --> src/main.rs:4:8
  |
4 | struct EditForm<'req> {
  |        ^^^^^^^^ expected lifetime parameter
  |
help: indicate the anonymous lifetime
  |
4 | struct EditForm<'_><'req> {
  |                ++++

```

With this pull request, the generics are simply copied onto the generated `impl RsHtml` block, allowing this code to compile.